### PR TITLE
Add ecs version

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -50,6 +50,9 @@ module Twiglet
 
     def log_message(level, message:)
       base_message = {
+        ecs: {
+          version: '1.5.0'
+        },
         "@timestamp": @now.call.iso8601(3),
         service: {
           name: @service_name

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.3.5'
+  VERSION = '2.3.6'
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -17,6 +17,9 @@ describe Twiglet::Formatter do
   it 'returns a formatted log from a string message' do
     msg = @formatter.call('warn', nil, nil, 'shop is running low on dog food')
     expected_log = {
+      "ecs" => {
+        "version" => '1.5.0'
+      },
       "@timestamp" => '2020-05-11T15:01:01.000Z',
       "service" => {
         "name" => 'petshop'

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -49,6 +49,9 @@ describe Twiglet::Logger do
 
       expected_log = {
         message: 'Out of pets exception',
+        ecs: {
+          version: '1.5.0'
+        },
         "@timestamp": '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
@@ -136,10 +139,10 @@ describe Twiglet::Logger do
       @logger.info({message: 'there'})
 
       expected_output =
-        '{"@timestamp":"2020-05-11T15:01:01.000Z",'\
+        '{"ecs":{"version":"1.5.0"},"@timestamp":"2020-05-11T15:01:01.000Z",'\
         '"service":{"name":"petshop"},"log":{"level":"debug"},"message":"hi"}'\
         "\n"\
-        '{"@timestamp":"2020-05-11T15:01:01.000Z",'\
+        '{"ecs":{"version":"1.5.0"},"@timestamp":"2020-05-11T15:01:01.000Z",'\
         '"service":{"name":"petshop"},"log":{"level":"info"},"message":"there"}'\
         "\n"\
 
@@ -251,6 +254,9 @@ describe Twiglet::Logger do
 
       expected_log = {
         message: 'Out of pets exception',
+        ecs: {
+          version: '1.5.0'
+        },
         "@timestamp": '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'


### PR DESCRIPTION
This adds the `ecs.version` field to the mandatory logging outputs.