### PR TITLE
Simplify version check by using public action

### DIFF
--- a/.github/workflows/version-forget-me-not.yml
+++ b/.github/workflows/version-forget-me-not.yml
@@ -3,25 +3,14 @@ name: Check version
 on:
   pull_request:
     branches:
-      - master # default branch
+      - master
     types: [opened, synchronize]
 jobs:
   build:
     runs-on: ubuntu-18.04
 
     steps:
-      # For private action we need to checkout the action repo.
-      # We can remove this once we make the action public.
-      - uses: actions/checkout@v1
-        with:
-          repository: simplybusiness/version-forget-me-not
-          ref: refs/tags/v1.0
-          # Do not put the actual secret here- only the name of the secret in your repo
-          token: ${{ secrets.BOT_TOKEN }}
-          path: './twiglet-ruby'
-      - uses: ./
+      - uses: simplybusiness/version-forget-me-not@v1
         env:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # It is the file path where you keep the version of gem.
-          # It usually in the `lib/<gem name>/version.rb` or in the gemspec file.
           VERSION_FILE_PATH: "lib/twiglet/version.rb"

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.3.8'
+  VERSION = '2.3.9'
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/nLZG2oBI/417-version-forget-me-not-github-action)

Now that the Github Action is published, we can simplify this quite a bit! 