### PR TITLE
Fix logger.error behavior with string message argument

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -5,6 +5,12 @@ module Twiglet
   class Formatter < ::Logger::Formatter
     Hash.include HashExtensions
 
+    MessageStrToLogObj = lambda do |message_str|
+      raise('The \'message\' property of log object must not be empty') if message_str.strip.empty?
+
+      { message: message_str }
+    end
+
     def initialize(service_name,
                    default_properties: {},
                    now: -> { Time.now.utc })
@@ -34,9 +40,7 @@ module Twiglet
     end
 
     def log_text(level, message:)
-      raise('The \'message\' property of log object must not be empty') if message.strip.empty?
-
-      message = { message: message }
+      message = MessageStrToLogObj.call(message)
       log_message(level, message: message)
     end
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -37,7 +37,8 @@ module Twiglet
           }
         }
         add_stack_trace(error_fields, error)
-        message.is_a?(Hash) ? message.merge!(error_fields) : error_fields.merge!(message: message)
+        message = Twiglet::Formatter::MessageStrToLogObj.call(message) if message.is_a?(String)
+        message.merge!(error_fields)
       end
 
       super(message, &block)

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -31,4 +31,25 @@ describe Twiglet::Formatter do
     }
     assert_equal JSON.parse(msg), expected_log
   end
+
+  describe Twiglet::Formatter::MessageStrToLogObj do
+    it 'converts string message to hash representation' do
+      msg = 'desired message string'
+      assert_equal Twiglet::Formatter::MessageStrToLogObj.call(msg), {message: 'desired message string'}
+    end
+
+    it 'raises an error when empty message is given' do
+      err = assert_raises RuntimeError, 'aa' do
+        Twiglet::Formatter::MessageStrToLogObj.call('')
+      end
+      assert_equal err.message, 'The \'message\' property of log object must not be empty'
+    end
+
+    it 'raises an error when given message contains whitespaces only' do
+      err = assert_raises RuntimeError, 'aa' do
+        Twiglet::Formatter::MessageStrToLogObj.call(" \n\t ")
+      end
+      assert_equal err.message, 'The \'message\' property of log object must not be empty'
+    end
+  end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -230,6 +230,16 @@ describe Twiglet::Logger do
       refute actual_log[:error].key?(:stack_trace)
     end
 
+    it 'should log an error with string message' do
+      e = StandardError.new('Unknown error')
+      @logger.error('Artificially raised exception with string message', e)
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'Artificially raised exception with string message', actual_log[:message]
+      assert_equal 'Unknown error', actual_log[:error][:message]
+    end
+
     LEVELS.each do |attrs|
       it "should correctly log level when calling #{attrs[:method]}" do
         @logger.public_send(attrs[:method], {message: 'a log message'})


### PR DESCRIPTION
Executing `error` with String given as an `message` argument
```ruby
logger.error("message", e)
```
were not adding `error.*` details to the log line.

Changes:
* fixed `Twiglet::Logger#error` method to work with string message as well
* extracted the `MessageStrToLogObj` lambda within `Twiglet::Logger::Formatter` to leave code DRY - should not be an issue as lib don't allow to inject custom formatter. Lambda choice can be a questionable choice so I'm open to other proposals that will be aligned with the library vision.