### PR TITLE
Bug fix logging error strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,21 @@ This will write to STDOUT a JSON string:
 {"service":{"name":"service name"},"@timestamp":"2020-05-14T10:54:59.164+01:00","log":{"level":"error"}, "message":"Emergency! There's an Emergency going on"}
 ```
 
-Errors can be logged as well, and this will log the error message and backtrace in the relevant ECS compliant fields:
+A message is always required unless a block is provided. The message can be an object or a string.
+
+An optional error can also be provided, in which case the error message and backtrace will be logged in the relevant ECS compliant fields:
 
 ```ruby
 db_err = StandardError.new('Connection timed-out')
 logger.error({ message: 'DB connection failed.' }, db_err)
+
+# this is also valid
+logger.error('DB connection failed.', db_err)
+```
+
+These will both result in the same JSON string written to STDOUT:
+```json
+{"ecs":{"version":"1.5.0"},"@timestamp":"2020-08-21T15:44:37.890Z","service":{"name":"service name"},"log":{"level":"error"},"message":"DB connection failed.","error":{"message":"Connection timed-out"}}
 ```
 
 Add log event specific information simply as attributes in a hash:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ This will write to STDOUT a JSON string:
 
 Obviously the timestamp will be different.
 
-Alternatively, if you just want to log some error message in text format
+Alternatively, if you just want to log some error string:
+
 ```ruby
 logger.error( "Emergency! There's an Emergency going on")
 ```
@@ -66,6 +67,7 @@ logger.error('DB connection failed.', db_err)
 ```
 
 These will both result in the same JSON string written to STDOUT:
+
 ```json
 {"ecs":{"version":"1.5.0"},"@timestamp":"2020-08-21T15:44:37.890Z","service":{"name":"service name"},"log":{"level":"error"},"message":"DB connection failed.","error":{"message":"Connection timed-out"}}
 ```
@@ -91,17 +93,17 @@ This writes:
 {"service":{"name":"service name"},"@timestamp":"2020-05-14T10:56:49.527+01:00","log":{"level":"info"},"event":{"action":"HTTP request"},"message":"GET /pets success","trace":{"id":"1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb"},"http":{"request":{"method":"get"},"response":{"status_code":200}},"url":{"path":"/pets"}}
 ```
 
-Similar to error you can use text logging here as:
+Similar to error you can use string logging here as:
 
 ```
 logger.info('GET /pets success')
 ```
+
 This writes:
 
 ```json
 {"service":{"name":"service name"},"@timestamp":"2020-05-14T10:56:49.527+01:00","log":{"level":"info"}}
 ```
-
 
 It may be that when making a series of logs that write information about a single event, you may want to avoid duplication by creating an event specific logger that includes the context:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Obviously the timestamp will be different.
 Alternatively, if you just want to log some error string:
 
 ```ruby
-logger.error( "Emergency! There's an Emergency going on")
+logger.error("Emergency! There's an Emergency going on")
 ```
 
 This will write to STDOUT a JSON string:

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -29,7 +29,7 @@ module Twiglet
       super(output, formatter: formatter, level: level)
     end
 
-    def error(message = {}, error = nil, &block)
+    def error(message = nil, error = nil, &block)
       if error
         error_fields = {
           'error': {
@@ -37,7 +37,7 @@ module Twiglet
           }
         }
         add_stack_trace(error_fields, error)
-        message.is_a?(Hash) ? message.merge!(error_fields) : error_fields.merge!(message: message)
+        message = message.is_a?(Hash) ? message.merge(error_fields) : error_fields.merge(message: message)
       end
 
       super(message, &block)

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.3.9'
+  VERSION = '2.3.10'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -230,6 +230,16 @@ describe Twiglet::Logger do
       refute actual_log[:error].key?(:stack_trace)
     end
 
+    it 'should log an error with string message' do
+      e = StandardError.new('Unknown error')
+      @logger.error('Artificially raised exception with string message', e)
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'Artificially raised exception with string message', actual_log[:message]
+      assert_equal 'Unknown error', actual_log[:error][:message]
+    end
+
     LEVELS.each do |attrs|
       it "should correctly log level when calling #{attrs[:method]}" do
         @logger.public_send(attrs[:method], {message: 'a log message'})


### PR DESCRIPTION
# Bug
We were not including error fields when `logger.error` was called with both a string message and an error

# Fix
We were failing to reassign the merged content of the error fields back to the original message variable https://github.com/simplybusiness/twiglet-ruby/commit/3d74c881c5d8f560d26545d06e2eb9d1a5b7ffa9

# Tech notes
This is an alternate solution to https://github.com/simplybusiness/twiglet-ruby/pull/10