### PR TITLE
Add error type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,21 @@
-.PHONY: all build test
+.PHONY: all build clean shell test
 
-all: build test
+all: clean build test
 
 build:
 	docker build -t simplybusiness/ruby-dev:2.6.5 .
 
+clean:
+	rm -f *~
+
+shell:
+	docker run -it \
+	-v `pwd`:/var/app \
+	simplybusiness/ruby-dev:2.6.5 \
+	bash
+
 test:
-	docker run -it -v `pwd`:/var/app simplybusiness/ruby-dev:2.6.5 bundle exec rake test
+	docker run -it \
+	-v `pwd`:/var/app \
+	simplybusiness/ruby-dev:2.6.5 \
+	bundle exec rake test

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -34,6 +34,7 @@ module Twiglet
       if error
         error_fields = {
           'error': {
+            'type': error.class,
             'message': error.message
           }
         }

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '2.3.11'
+  VERSION = '2.4.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -36,7 +36,6 @@ describe Twiglet::Logger do
     end
   end
 
-
   describe 'JSON logging' do
     it 'should throw an error with an empty message' do
       assert_raises RuntimeError do
@@ -184,7 +183,6 @@ describe Twiglet::Logger do
     end
   end
 
-
   describe 'logging an exception' do
     it 'should log an error with backtrace' do
       begin
@@ -224,7 +222,6 @@ describe Twiglet::Logger do
       assert_equal 'Unknown error', actual_log[:error][:message]
     end
   end
-
 
   describe 'text logging' do
     it 'should throw an error with an empty message' do
@@ -272,7 +269,6 @@ describe Twiglet::Logger do
     end
   end
 
-
   describe 'logging with a block' do
     LEVELS.each do |attrs|
       it "should correctly log the block when calling #{attrs[:method]}" do
@@ -285,7 +281,6 @@ describe Twiglet::Logger do
       end
     end
   end
-
 
   describe 'dotted keys' do
     it 'should be able to convert dotted keys to nested objects' do
@@ -321,7 +316,6 @@ describe Twiglet::Logger do
       assert_equal 'Bitsa', log[:pet][:breed]
     end
   end
-
 
   describe 'logger level' do
     [


### PR DESCRIPTION
This fixes issue: https://trello.com/c/fTGPQgqp/447-twiglet-should-log-the-error-class
Where the type of the exception was not logged, merely the message.