### PR TITLE
ECS complaint logs schema

### DIFF
--- a/examples/rack/request_logger.rb
+++ b/examples/rack/request_logger.rb
@@ -11,7 +11,7 @@ class RequestLogger
     [status, headers, body]
   rescue StandardError => e
     log_error(env, 500, e)
-    [500, {}, body]
+    raise e
   end
 
   private
@@ -26,24 +26,41 @@ class RequestLogger
     @logger.error(fields, error)
   end
 
+  # https://www.elastic.co/guide/en/ecs/1.5/ecs-field-reference.html
   def get_fields(env, status)
     message = "#{env['REQUEST_METHOD']}: #{env['PATH_INFO']}"
 
     {
-      http: {
-        request: {
-          method: env['REQUEST_METHOD'],
-          server: env['SERVER_NAME'],
-          https_enabled: env['HTTPS'],
-          path: env['PATH_INFO'],
-          query: env['QUERY_STRING']  # Don't log PII query params
-        },
-        response: {
-          status: status,
-          body: { bytes: env['CONTENT_LENGTH'] }
-        }
+      http: http_fields(env, status),
+      url: url_fields(env),
+      client: {
+        ip: env['HTTP_TRUE_CLIENT_IP'] || env['REMOTE_ADDR']
+      },
+      user_agent: {
+        original: env['HTTP_USER_AGENT']
       },
       message: message
+    }
+  end
+
+  def http_fields(env, status)
+    {
+      request: {
+        method: env['REQUEST_METHOD'],
+        mime_type: env['HTTP_ACCEPT']
+      },
+      response: {
+        status: status
+      },
+      version: env['HTTP_VERSION']
+    }
+  end
+
+  def url_fields(env)
+    {
+      path: env['PATH_INFO'],
+      query: env['QUERY_STRING'],
+      domain: env['SERVER_NAME']
     }
   end
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.0.1'
+  VERSION = '3.0.2'
 end


### PR DESCRIPTION
### What

 - Change the schema so logs will be ECS complaint.
 - Propagate the error to next middleware

### Why

So we can have better logs structure.


@simplybusiness/silversmiths 