### PR TITLE
Validate log format using JSON schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
+
+gem 'json-schema'
+
 group :development, :test do
   gem 'minitest'
   gem 'rake'

--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -10,9 +10,8 @@ module Twiglet
     Hash.include HashExtensions
 
     def initialize(service_name,
-                   default_properties: {},
-                   now: -> { Time.now.utc },
-                   validator:)
+                   validator:, default_properties: {},
+                   now: -> { Time.now.utc })
       @service_name = service_name
       @now = now
       @default_properties = default_properties

--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -5,8 +5,6 @@ require_relative 'validator'
 
 module Twiglet
   class Formatter < ::Logger::Formatter
-    attr_accessor :validation_error_response
-
     Hash.include HashExtensions
 
     def initialize(service_name,

--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -11,13 +11,12 @@ module Twiglet
 
     def initialize(service_name,
                    default_properties: {},
-                   now: -> { Time.now.utc })
+                   now: -> { Time.now.utc },
+                   validator:)
       @service_name = service_name
       @now = now
       @default_properties = default_properties
-      @validation_error_response = ->(msg) { raise "Schema validation error for #{msg}" }
-
-      @validator = Validator.from_file('lib/twiglet/validation_schema.json')
+      @validator = validator
 
       super()
     end
@@ -25,9 +24,7 @@ module Twiglet
     def call(severity, _time, _progname, msg)
       level = severity.downcase
       message = Message.new(msg)
-      @validator.validate(message) do
-        @validation_error_response.call(message)
-      end
+      @validator.validate(message)
       log(level: level, message: message)
     end
 

--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require_relative '../hash_extensions'
 require_relative 'message'
+require_relative 'validator'
 
 module Twiglet
   class Formatter < ::Logger::Formatter
@@ -13,12 +14,18 @@ module Twiglet
       @now = now
       @default_properties = default_properties
 
+      @validator = Validator.from_file('lib/twiglet/validation_schema.json')
+
       super()
     end
 
     def call(severity, _time, _progname, msg)
       level = severity.downcase
-      log(level: level, message: Message.new(msg))
+      message = Message.new(msg)
+      @validator.validate(message) do
+        raise 'Schema validation error'
+      end
+      log(level: level, message: message)
     end
 
     private

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -38,7 +38,7 @@ module Twiglet
     end
 
     def configure_validation_error_response(&block)
-      @validator.configure_validation_error(&block)
+      @validator.custom_error_handler = block
     end
 
     def error(message = nil, error = nil, &block)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -28,10 +28,12 @@ module Twiglet
 
       @validator = Validator.from_file('lib/twiglet/validation_schema.json')
 
-      @formatter = Twiglet::Formatter.new(service_name,
-                                          default_properties: default_properties,
-                                          now: now,
-                                          validator: @validator)
+      @formatter = Twiglet::Formatter.new(
+        service_name,
+        default_properties: default_properties,
+        now: now,
+        validator: @validator
+      )
       super(output, formatter: @formatter, level: level)
     end
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -26,8 +26,12 @@ module Twiglet
       raise 'Service name is mandatory' \
         unless service_name.is_a?(String) && !service_name.strip.empty?
 
-      formatter = Twiglet::Formatter.new(service_name, default_properties: default_properties, now: now)
-      super(output, formatter: formatter, level: level)
+      @formatter = Twiglet::Formatter.new(service_name, default_properties: default_properties, now: now)
+      super(output, formatter: @formatter, level: level)
+    end
+
+    def configure_validation_error_response(&block)
+      @formatter.validation_error_response = block
     end
 
     def error(message = nil, error = nil, &block)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -26,12 +26,17 @@ module Twiglet
       raise 'Service name is mandatory' \
         unless service_name.is_a?(String) && !service_name.strip.empty?
 
-      @formatter = Twiglet::Formatter.new(service_name, default_properties: default_properties, now: now)
+      @validator = Validator.from_file('lib/twiglet/validation_schema.json')
+
+      @formatter = Twiglet::Formatter.new(service_name,
+                                          default_properties: default_properties,
+                                          now: now,
+                                          validator: @validator)
       super(output, formatter: @formatter, level: level)
     end
 
     def configure_validation_error_response(&block)
-      @formatter.validation_error_response = block
+      @validator.configure_validation_error(&block)
     end
 
     def error(message = nil, error = nil, &block)

--- a/lib/twiglet/message.rb
+++ b/lib/twiglet/message.rb
@@ -10,18 +10,6 @@ module Twiglet
       else
         super(msg)
       end
-
-      validate!
-    end
-
-    private
-
-    def validate!
-      raise 'Message must be initialized with a String or a non-empty Hash' if empty?
-
-      raise 'Log object must have a \'message\' property' unless self[:message]
-
-      raise 'The \'message\' property of the log object must not be empty' if self[:message].strip.empty?
     end
   end
 end

--- a/lib/twiglet/validation_schema.json
+++ b/lib/twiglet/validation_schema.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "required": ["message"],
+  "properties": {
+    "message": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/lib/twiglet/validator.rb
+++ b/lib/twiglet/validator.rb
@@ -7,16 +7,21 @@ module Twiglet
   class Validator
     def initialize(schema)
       @schema = schema
+      @custom_error_handler = ->(e) { raise e }
     end
 
     def self.from_file(file_path)
       new(JSON.parse(File.read(file_path)))
     end
 
-    def validate(message)
-      return unless block_given?
+    def configure_validation_error(&block)
+      @custom_error_handler = block
+    end
 
-      yield message unless JSON::Validator.validate(@schema, message)
+    def validate(message)
+      JSON::Validator.validate!(@schema, message)
+    rescue JSON::Schema::ValidationError => e
+      @custom_error_handler.call(e)
     end
   end
 end

--- a/lib/twiglet/validator.rb
+++ b/lib/twiglet/validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'json-schema'
+require 'json'
+
+module Twiglet
+  class Validator
+    def initialize(schema)
+      @schema = schema
+    end
+
+    def self.from_file(file_path)
+      new(JSON.parse(File.read(file_path)))
+    end
+
+    def validate(message, &block)
+      return unless block_given?
+
+      yield unless JSON::Validator.validate(@schema, message)
+    end
+  end
+end

--- a/lib/twiglet/validator.rb
+++ b/lib/twiglet/validator.rb
@@ -5,6 +5,8 @@ require 'json'
 
 module Twiglet
   class Validator
+    attr_accessor :custom_error_handler
+
     def initialize(schema)
       @schema = schema
       @custom_error_handler = ->(e) { raise e }
@@ -14,14 +16,10 @@ module Twiglet
       new(JSON.parse(File.read(file_path)))
     end
 
-    def configure_validation_error(&block)
-      @custom_error_handler = block
-    end
-
     def validate(message)
       JSON::Validator.validate!(@schema, message)
     rescue JSON::Schema::ValidationError => e
-      @custom_error_handler.call(e)
+      custom_error_handler.call(e)
     end
   end
 end

--- a/lib/twiglet/validator.rb
+++ b/lib/twiglet/validator.rb
@@ -13,10 +13,10 @@ module Twiglet
       new(JSON.parse(File.read(file_path)))
     end
 
-    def validate(message, &block)
+    def validate(message)
       return unless block_given?
 
-      yield unless JSON::Validator.validate(@schema, message)
+      yield message unless JSON::Validator.validate(@schema, message)
     end
   end
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.0.8'
+  VERSION = '3.1.0'
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -3,11 +3,12 @@
 require 'minitest/autorun'
 require 'json'
 require_relative '../lib/twiglet/formatter'
+require_relative '../lib/twiglet/validator'
 
 describe Twiglet::Formatter do
   before do
     @now = -> { Time.utc(2020, 5, 11, 15, 1, 1) }
-    @formatter = Twiglet::Formatter.new('petshop', now: @now)
+    @formatter = Twiglet::Formatter.new('petshop', now: @now, validator: Twiglet::Validator.new({}))
   end
 
   it 'initializes an instance of a Ruby Logger Formatter' do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'minitest/mock'
 require_relative '../lib/twiglet/logger'
 
 LEVELS = [
@@ -355,6 +356,25 @@ describe Twiglet::Logger do
 
     it 'initializes the logger with the provided level' do
       assert_equal Logger::WARN, Twiglet::Logger.new('petshop', level: :warn).level
+    end
+  end
+
+  describe 'configuring error response' do
+    it 'blows up by default' do
+      assert_raises RuntimeError do
+        @logger.debug(message: true)
+      end
+    end
+
+    it 'silently swallows errors when configured to do so' do
+      apm = Minitest::Mock.new
+      apm.expect(:notify_error, nil, ["Logging schema validation error for {:message=>true}"])
+
+      @logger.configure_validation_error_response do |msg|
+        apm.notify_error("Logging schema validation error for #{msg}")
+      end
+
+      @logger.debug({ message: true })
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -361,7 +361,8 @@ describe Twiglet::Logger do
 
   describe 'configuring error response' do
     it 'blows up by default' do
-      assert_raises JSON::Schema::ValidationError, "The property '#/message' of type boolean did not match the following type: string" do
+      assert_raises JSON::Schema::ValidationError,
+                    "The property '#/message' of type boolean did not match the following type: string" do
         @logger.debug(message: true)
       end
     end
@@ -370,7 +371,7 @@ describe Twiglet::Logger do
       apm = Minitest::Mock.new
       apm.expect(:notify_error, nil, ["Logging schema validation error"])
 
-      @logger.configure_validation_error_response do |e|
+      @logger.configure_validation_error_response do |_e|
         apm.notify_error("Logging schema validation error")
       end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -375,7 +375,8 @@ describe Twiglet::Logger do
       end
 
       mock.expect(:notify_error, nil, ["Logging schema validation error"])
-      @logger.debug({ message: true })
+      nonconformant_log = { message: true }
+      @logger.debug(nonconformant_log)
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -43,13 +43,13 @@ describe Twiglet::Logger do
 
   describe 'JSON logging' do
     it 'should throw an error with an empty message' do
-      assert_raises RuntimeError do
+      assert_raises JSON::Schema::ValidationError, "The property '#/message' was not of a minimum string length of 1" do
         @logger.info({ message: '' })
       end
     end
 
     it 'should throw an error if message is missing' do
-      assert_raises RuntimeError do
+      assert_raises JSON::Schema::ValidationError, "The property '#/message' was not of a minimum string length of 1" do
         @logger.info({ foo: 'bar' })
       end
     end
@@ -246,7 +246,7 @@ describe Twiglet::Logger do
 
   describe 'text logging' do
     it 'should throw an error with an empty message' do
-      assert_raises RuntimeError do
+      assert_raises JSON::Schema::ValidationError, "The property '#/message' was not of a minimum string length of 1" do
         @logger.info('')
       end
     end
@@ -361,17 +361,17 @@ describe Twiglet::Logger do
 
   describe 'configuring error response' do
     it 'blows up by default' do
-      assert_raises RuntimeError do
+      assert_raises JSON::Schema::ValidationError, "The property '#/message' of type boolean did not match the following type: string" do
         @logger.debug(message: true)
       end
     end
 
     it 'silently swallows errors when configured to do so' do
       apm = Minitest::Mock.new
-      apm.expect(:notify_error, nil, ["Logging schema validation error for {:message=>true}"])
+      apm.expect(:notify_error, nil, ["Logging schema validation error"])
 
-      @logger.configure_validation_error_response do |msg|
-        apm.notify_error("Logging schema validation error for #{msg}")
+      @logger.configure_validation_error_response do |e|
+        apm.notify_error("Logging schema validation error")
       end
 
       @logger.debug({ message: true })

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -368,13 +368,13 @@ describe Twiglet::Logger do
     end
 
     it 'silently swallows errors when configured to do so' do
-      apm = Minitest::Mock.new
-      apm.expect(:notify_error, nil, ["Logging schema validation error"])
+      mock = Minitest::Mock.new
 
       @logger.configure_validation_error_response do |_e|
-        apm.notify_error("Logging schema validation error")
+        mock.notify_error("Logging schema validation error")
       end
 
+      mock.expect(:notify_error, nil, ["Logging schema validation error"])
       @logger.debug({ message: true })
     end
   end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -47,6 +47,12 @@ describe Twiglet::Logger do
       end
     end
 
+    it 'should throw an error if message is missing' do
+      assert_raises RuntimeError do
+        @logger.info({ foo: 'bar' })
+      end
+    end
+
     it 'should log mandatory attributes' do
       @logger.error({ message: 'Out of pets exception' })
       actual_log = read_json(@buffer)

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -2,24 +2,6 @@ require 'minitest/autorun'
 require_relative '../lib/twiglet/message'
 
 describe Twiglet::Message do
-  it 'raises if message is empty' do
-    assert_raises RuntimeError do
-      Twiglet::Message.new('   ')
-    end
-  end
-
-  it 'raises if message is not provided' do
-    assert_raises RuntimeError do
-      Twiglet::Message.new(foo: 'bar')
-    end
-  end
-
-  it 'raises on unrecognized inputs' do
-    assert_raises RuntimeError do
-      Twiglet::Message.new(OpenStruct.new(message: 'hello'))
-    end
-  end
-
   it 'returns a message hash from a string' do
     assert_equal Twiglet::Message.new('hello, world'), { message: 'hello, world' }
   end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -8,7 +8,7 @@ describe Twiglet::Validator do
 
   before do
     schema = {
-      "type"=>"object",
+      "type" => "object",
       "required" => ["message"],
       "properties" => {
         "message" => {

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -20,25 +20,19 @@ describe Twiglet::Validator do
     @validator = Twiglet::Validator.new(schema)
   end
 
-  it 'is a no-op when validation passes' do
-    assert_nil(
-      @validator.validate({ message: 'this is my message', foo: 'bar' }) do
-        raise 'I will throw this error if validation fails'
-      end
-    )
+  it 'does not raise when validation passes' do
+    assert_equal(@validator.validate({ message: 'this is my message', foo: 'bar' }), true)
   end
 
-  it 'executes the block provided when validation fails' do
-    assert_raises 'I will throw this error if validation fails' do
-      @validator.validate({ message: true }) do
-        raise 'I will throw this error if validation fails'
-      end
+  it 'raises when validation fails' do
+    assert_raises JSON::Schema::ValidationError do
+      @validator.validate({ message: true })
     end
   end
 
-  it 'is a no-op when validation fails but no block is provided' do
-    assert_nil(
-      @validator.validate({ message: true })
-    )
+  it 'is a no-op when validator is configured to swallow errors' do
+    @validator.configure_validation_error { |e| puts e }
+
+    assert_nil(@validator.validate({ message: true }))
   end
 end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -31,7 +31,7 @@ describe Twiglet::Validator do
   end
 
   it 'is a no-op when validator is configured to swallow errors' do
-    @validator.configure_validation_error { |e| puts e }
+    @validator.custom_error_handler = ->(e) { puts e }
 
     assert_nil(@validator.validate({ message: true }))
   end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -22,7 +22,7 @@ describe Twiglet::Validator do
 
   it 'is a no-op when validation passes' do
     assert_nil(
-      @validator.validate({ message: 'this is my message' }) do
+      @validator.validate({ message: 'this is my message', foo: 'bar' }) do
         raise 'I will throw this error if validation fails'
       end
     )

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/twiglet/validator'
+
+describe Twiglet::Validator do
+  let(:valid)
+
+  before do
+    schema = {
+      "type"=>"object",
+      "required" => ["message"],
+      "properties" => {
+        "message" => {
+          "type" => "string"
+        }
+      }
+    }
+
+    @validator = Twiglet::Validator.new(schema)
+  end
+
+  it 'is a no-op when validation passes' do
+    assert_nil(
+      @validator.validate({ message: 'this is my message' }) do
+        raise 'I will throw this error if validation fails'
+      end
+    )
+  end
+
+  it 'executes the block provided when validation fails' do
+    assert_raises 'I will throw this error if validation fails' do
+      @validator.validate({ message: true }) do
+        raise 'I will throw this error if validation fails'
+      end
+    end
+  end
+
+  it 'is a no-op when validation fails but no block is provided' do
+    assert_nil(
+      @validator.validate({ message: true })
+    )
+  end
+end


### PR DESCRIPTION
# What 
This uses a JSON schema to validate Twiglet messages are formatting correctly

# Next steps
- [x] Make the callback for handling invalid log messages configurable (i.e. configure to report to an application monitoring service rather than raising a runtime error)
- [ ] Make the schema configurable