### PR TITLE
Change to return stack trace as list

### DIFF
--- a/examples/rack/request_logger_test.rb
+++ b/examples/rack/request_logger_test.rb
@@ -70,7 +70,7 @@ describe RequestLogger do
     assert_equal log['log']['level'], 'error'
     assert_equal log['error']['message'], 'some exception'
     assert_equal log['error']['type'], 'StandardError'
-    assert_includes log['error']['stack_trace'], 'request_logger_test.rb'
+    assert_includes log['error']['stack_trace'].first, 'examples/rack/request_logger_test.rb'
   end
 end
 

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -70,7 +70,7 @@ module Twiglet
     private
 
     def add_stack_trace(hash_to_add_to, error)
-      hash_to_add_to[:error][:stack_trace] = error.backtrace.join("\n") if error.backtrace
+      hash_to_add_to[:error][:stack_trace] = error.backtrace if error.backtrace
     end
   end
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.2.5'
+  VERSION = '3.3.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -217,7 +217,7 @@ describe Twiglet::Logger do
       assert_equal 'Artificially raised exception', actual_log[:message]
       assert_equal 'divided by 0', actual_log[:error][:message]
       assert_equal 'ZeroDivisionError', actual_log[:error][:type]
-      assert_match 'logger_test.rb', actual_log[:error][:stack_trace].first
+      assert_match 'test/logger_test.rb', actual_log[:error][:stack_trace].first
     end
 
     it 'should log an error without backtrace' do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -217,7 +217,7 @@ describe Twiglet::Logger do
       assert_equal 'Artificially raised exception', actual_log[:message]
       assert_equal 'divided by 0', actual_log[:error][:message]
       assert_equal 'ZeroDivisionError', actual_log[:error][:type]
-      assert_match 'logger_test.rb', actual_log[:error][:stack_trace].lines.first
+      assert_match 'logger_test.rb', actual_log[:error][:stack_trace].first
     end
 
     it 'should log an error without backtrace' do


### PR DESCRIPTION
This is a bug fix to follow the ECS format and return the stack trace as a list to help with debugging.