### PR TITLE
Log error class as string

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -46,7 +46,7 @@ module Twiglet
       if error
         error_fields = {
           error: {
-            type: error.class,
+            type: error.class.to_s,
             message: error.message
           }
         }

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.3.6'
+  VERSION = '3.3.7'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -242,6 +242,16 @@ describe Twiglet::Logger do
       assert_equal 'StandardError', actual_log[:error][:type]
       assert_equal 'Unknown error', actual_log[:error][:message]
     end
+
+    it 'should log error type properly even when active_support/json is required' do
+      require 'active_support/json'
+      e = StandardError.new('Unknown error')
+      @logger.error('Artificially raised exception with string message', e)
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'StandardError', actual_log[:error][:type]
+    end
   end
 
   describe 'text logging' do


### PR DESCRIPTION
### Why

When I started setting up a new service and used twiglet I realised that there was a spec failing for logger once I required  `mongoid`. I spent some time digging and it turned out that mongoid requires `activesupport/json` which breaks logging. Twiglet::Formatter calls `to_json` on the log.

Example from the console
```ruby
require 'json'
=> true
irb(main):004:0> {test: StandardError }.to_json
=> "{\"test\":\"StandardError\"}"
irb(main):005:0> require "active_support/json"
=> true
irb(main):006:0> {test: StandardError }.to_json
=> "{\"test\":{}}"
```

