### PR TITLE
Reduce Gem Publish GitHub Action permissions

### DIFF
--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and Publish

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.4.2'
+  VERSION = '3.4.3'
 end


### PR DESCRIPTION
Since the only API call is to create a release, this is what is needed: https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents

Issue: https://github.com/simplybusiness/twiglet-ruby/issues/51