### PR TITLE
Add a setting to automatically add context information when logging

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -7,11 +7,14 @@ module Twiglet
     Hash.include HashExtensions
 
     def initialize(service_name,
-                   validator:, default_properties: {},
+                   validator:,
+                   default_properties: {},
+                   context_provider: nil,
                    now: -> { Time.now.utc })
       @service_name = service_name
       @now = now
       @default_properties = default_properties
+      @context_provider = context_provider
       @validator = validator
 
       super()
@@ -40,8 +43,11 @@ module Twiglet
         }
       }
 
+      context = @context_provider&.call || {}
+
       base_message
         .deep_merge(@default_properties.to_nested)
+        .deep_merge(context.to_nested)
         .deep_merge(message.to_nested)
         .to_json
         .concat("\n")

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -58,14 +58,14 @@ module Twiglet
     end
 
     def with(default_properties)
-      Logger.new(
+      self.class.new(
         @service_name,
         **@args.merge(default_properties: default_properties)
       )
     end
 
     def context_provider(&blk)
-      Logger.new(
+      self.class.new(
         @service_name,
         **@args.merge(context_provider: blk)
       )

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -16,8 +16,6 @@ module Twiglet
       **args
     )
       @service_name = service_name
-      default_properties = args.delete(:default_properties) || {}
-      context_provider = args.delete(:context_provider)
       @args = args
 
       now = args.fetch(:now, -> { Time.now.utc })
@@ -32,8 +30,8 @@ module Twiglet
 
       formatter = Twiglet::Formatter.new(
         service_name,
-        default_properties: default_properties,
-        context_provider: context_provider,
+        default_properties: args.fetch(:default_properties, {}),
+        context_provider: args[:context_provider],
         now: now,
         validator: @validator
       )

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -17,6 +17,7 @@ module Twiglet
     )
       @service_name = service_name
       default_properties = args.delete(:default_properties) || {}
+      context_provider = args.delete(:context_provider)
       @args = args
 
       now = args.fetch(:now, -> { Time.now.utc })
@@ -32,6 +33,7 @@ module Twiglet
       formatter = Twiglet::Formatter.new(
         service_name,
         default_properties: default_properties,
+        context_provider: context_provider,
         now: now,
         validator: @validator
       )
@@ -61,6 +63,13 @@ module Twiglet
       Logger.new(
         @service_name,
         **@args.merge(default_properties: default_properties)
+      )
+    end
+
+    def context_provider(&blk)
+      Logger.new(
+        @service_name,
+        **@args.merge(context_provider: blk)
       )
     end
 

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.4.9'
+  VERSION = '3.5.0'
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -32,4 +32,30 @@ describe Twiglet::Formatter do
     }
     assert_equal JSON.parse(msg), expected_log
   end
+
+  it 'merges the outputs of the context provider into messages logs' do
+    provider = -> { { 'request' => { 'id' => '1234567890' } } }
+    formatter = Twiglet::Formatter.new(
+      'petshop', now: @now, validator: Twiglet::Validator.new({}.to_json),
+                 context_provider: provider
+    )
+    msg = formatter.call('warn', nil, nil, 'shop is running low on dog food')
+    expected_log = {
+      "ecs" => {
+        "version" => '1.5.0'
+      },
+      "@timestamp" => '2020-05-11T15:01:01.000Z',
+      "service" => {
+        "name" => 'petshop'
+      },
+      "log" => {
+        "level" => 'warn'
+      },
+      "message" => 'shop is running low on dog food',
+      "request" => {
+        'id' => '1234567890'
+      }
+    }
+    assert_equal JSON.parse(msg), expected_log
+  end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -146,6 +146,25 @@ describe Twiglet::Logger do
       assert_equal 'Barker', log[:pet][:name]
     end
 
+    it "should be able to add contextual information to events with the context_provider" do
+      purchase_logger = @logger.context_provider do
+         { 'context' => {'id' => 'my-context-id' } }
+      end
+
+      # do stuff
+      purchase_logger.info(
+        {
+          message: 'customer bought a dog',
+          pet: { name: 'Barker', species: 'dog', breed: 'Bitsa' }
+        }
+      )
+
+      log = read_json @buffer
+
+      assert_equal 'customer bought a dog', log[:message]
+      assert_equal 'my-context-id', log[:context][:id]
+    end
+
     it "should log 'message' string property" do
       message = {}
       message['message'] = 'Guinea pigs arrived'


### PR DESCRIPTION
This PR introduces a new capability to add context information into
every log message using a block

This is inteneded to be used so that we can inject trace and span
context information from an o11y library into our log messages so that
we can correlate between traces and logs.

Currently, when adding this information into logs we are having to wrap
the Twiglet::Logger in a delegator or subclass which reimplements some
of its interface and internals. Each team has done this in a different
way, which will lead to a long term maintenance problem so providing an API
for this will hopefully reduce our maintenance costs.

Note: `.with` doesn't provide this behaviour as we need to change the context
information on every log event. It also allocates a new logger, which is
unnecessary.