### PR TITLE
Allow errors in non error logs

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -51,7 +51,7 @@ module Twiglet
           }
         }
         add_stack_trace(error_fields, error)
-        message = Message.new(message).merge(error_fields)
+        message = Message.new(message || error.message).merge(error_fields)
       end
 
       super(message, &block)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -43,21 +43,21 @@ module Twiglet
     end
 
     def debug(message_or_error = nil, &block)
-      message_or_error = error_message(message_or_error, '') if message_or_error.is_a?(Exception)
+      message = message_or_error.is_a?(Exception) ? error_message(message_or_error) : message_or_error
 
-      super(message_or_error, &block)
+      super(message, &block)
     end
 
     def info(message_or_error = nil, &block)
-      message_or_error = error_message(message_or_error, '') if message_or_error.is_a?(Exception)
+      message = message_or_error.is_a?(Exception) ? error_message(message_or_error) : message_or_error
 
-      super(message_or_error, &block)
+      super(message, &block)
     end
 
     def warn(message_or_error = nil, &block)
-      message_or_error = error_message(message_or_error, '') if message_or_error.is_a?(Exception)
+      message = message_or_error.is_a?(Exception) ? error_message(message_or_error) : message_or_error
 
-      super(message_or_error, &block)
+      super(message, &block)
     end
 
     def error(message = nil, error = nil, &block)
@@ -85,7 +85,7 @@ module Twiglet
 
     private
 
-    def error_message(error, message)
+    def error_message(error, message = nil)
       error_fields = {
         error: {
           type: error.class.to_s,

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -42,6 +42,24 @@ module Twiglet
       @validator.custom_error_handler = block
     end
 
+    def debug(message_or_error = nil, &block)
+      message_or_error = error_message(message_or_error, '') if message_or_error.is_a?(Exception)
+
+      super(message_or_error, &block)
+    end
+
+    def info(message_or_error = nil, &block)
+      message_or_error = error_message(message_or_error, '') if message_or_error.is_a?(Exception)
+
+      super(message_or_error, &block)
+    end
+
+    def warn(message_or_error = nil, &block)
+      message_or_error = error_message(message_or_error, '') if message_or_error.is_a?(Exception)
+
+      super(message_or_error, &block)
+    end
+
     def error(message = nil, error = nil, &block)
       message = error_message(error, message) if error
 
@@ -75,7 +93,8 @@ module Twiglet
         }
       }
       add_stack_trace(error_fields, error)
-      Message.new(message || error.message).merge(error_fields)
+      message = error.message if message.nil? || message.empty?
+      Message.new(message).merge(error_fields)
     end
 
     def add_stack_trace(hash_to_add_to, error)

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -43,16 +43,7 @@ module Twiglet
     end
 
     def error(message = nil, error = nil, &block)
-      if error
-        error_fields = {
-          error: {
-            type: error.class.to_s,
-            message: error.message
-          }
-        }
-        add_stack_trace(error_fields, error)
-        message = Message.new(message || error.message).merge(error_fields)
-      end
+      message = error_message(error, message) if error
 
       super(message, &block)
     end
@@ -75,6 +66,17 @@ module Twiglet
     alias_method :critical, :fatal
 
     private
+
+    def error_message(error, message)
+      error_fields = {
+        error: {
+          type: error.class.to_s,
+          message: error.message
+        }
+      }
+      add_stack_trace(error_fields, error)
+      Message.new(message || error.message).merge(error_fields)
+    end
 
     def add_stack_trace(hash_to_add_to, error)
       hash_to_add_to[:error][:stack_trace] = error.backtrace if error.backtrace

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.5.4'
+  VERSION = '3.6.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -445,6 +445,15 @@ describe Twiglet::Logger do
         assert_equal 'a block log message', actual_log[:message]
       end
     end
+
+    it 'should ignore the given progname if a block is also given' do
+      block = proc { 'a block log message' }
+      @logger.info('my-program-name', &block)
+      actual_log = read_json(@buffer)
+
+      assert_equal 'info', actual_log[:log][:level]
+      assert_equal 'a block log message', actual_log[:message]
+    end
   end
 
   describe 'dotted keys' do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -362,7 +362,7 @@ describe Twiglet::Logger do
       assert_equal 'StandardError', actual_log[:error][:type]
     end
 
-    it 'does not require a message to be sent' do
+    it 'can log just an error as "error", if no message is given' do
       e = StandardError.new('some error')
       @logger.error(nil, e)
 
@@ -371,6 +371,20 @@ describe Twiglet::Logger do
       assert_equal 'some error', actual_log[:message]
       assert_equal 'StandardError', actual_log[:error][:type]
       assert_equal 'some error', actual_log[:error][:message]
+    end
+
+    [:debug, :info, :warn].each do |level|
+      it "can log an error with type, error message etc.. as '#{level}'" do
+        error_message = "error to be logged as #{level}"
+        e = StandardError.new(error_message)
+        @logger.public_send(level, e)
+
+        actual_log = read_json(@buffer)
+
+        assert_equal error_message, actual_log[:message]
+        assert_equal 'StandardError', actual_log[:error][:type]
+        assert_equal error_message, actual_log[:error][:message]
+      end
     end
   end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -361,6 +361,17 @@ describe Twiglet::Logger do
 
       assert_equal 'StandardError', actual_log[:error][:type]
     end
+
+    it 'does not require a message to be sent' do
+      e = StandardError.new('some error')
+      @logger.error(nil, e)
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'some error', actual_log[:message]
+      assert_equal 'StandardError', actual_log[:error][:type]
+      assert_equal 'some error', actual_log[:error][:message]
+    end
   end
 
   describe 'text logging' do

--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.description           = 'Like a log, only smaller.'
 
   gem.files                 = `git ls-files`.split("\n")
-  gem.test_files            = `git ls-files -- {test}/*`.split("\n")
 
   gem.require_paths         = ['lib']
   gem.required_ruby_version = '>= 2.6'


### PR DESCRIPTION
## What
allow errors to be logged in any severity, not just `error`
(e.g. `logger.info(error)`)

## Why
we may want to log an error that occurred (e.g. its type, stack trace etc.), but the severity of this logging is not necessarily `error`.
for example, for a validation error, this does not indicate a bug in our program, so it's not an `error`. 
we want to log it as an `info` that a validation error occurred.

Specifically, I was working on adding more logging to `customer-management`, where there is a repeating pattern such as:

```
    rescue_from Grape::Exceptions::ValidationErrors do |e|
      error!(e.message, http_status_code(:bad_request))
    end
```
I'd like to log the exception that happened, including stack trace, type etc.
however, it doesn't constitute an actual bug in the application, so should not be logged as `error`:
```
    rescue_from Grape::Exceptions::ValidationErrors do |e|
      logger.log(e)
      error!(e.message, http_status_code(:bad_request))
    end
```

here's a [real-life example](https://github.com/simplybusiness/customer-management/pull/1619/commits/7fdabd7d9e19bffdecb7d567db51f70c25f54320#diff-657d332043b5574356d4824f795bf4a5916f56c193dbcfd1b7bdbb3adaeb9504R8)

## How
use the same method that we used in the `error` method to add error-related information in all other methods.