### PR TITLE
Read validation schema when file is required

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -10,6 +10,7 @@ require_relative 'validator'
 module Twiglet
   class Logger < ::Logger
     Hash.include HashExtensions
+    DEFAULT_VALIDATION_SCHEMA = File.read("#{__dir__}/validation_schema.json")
 
     def initialize(
       service_name,
@@ -21,7 +22,7 @@ module Twiglet
       now = args.fetch(:now, -> { Time.now.utc })
       output = args.fetch(:output, $stdout)
       level = args.fetch(:level, DEBUG)
-      validation_schema = args.fetch(:validation_schema, File.read("#{__dir__}/validation_schema.json"))
+      validation_schema = args.fetch(:validation_schema, DEFAULT_VALIDATION_SCHEMA)
 
       raise 'Service name is mandatory' \
         unless service_name.is_a?(String) && !service_name.strip.empty?

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.6.7'
+  VERSION = '3.7.0'
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.6.6'
+  VERSION = '3.6.7'
 end


### PR DESCRIPTION
This avoids reading the validation schema file every single time the Twiglet logger initializer is run. That file doesn't change between calls to .new - it changes only when new gem versions are released.

This was causing Polycomm to crash a lot with:
Errno::EMFILE:  Too many open files @ rb_sysopen - /home/sbapp/.bundle/gems/twiglet-3.6.6/lib/twiglet/validation_schema.json

Because it initialises new Twiglet loggers for every extra bit of data it includes in the logging context (multiple calls to Twiglet::Logger.new for every Kafka message it processes).

Since Twiglet includes a pattern of binding extra context via calls to Logger.new, this should not be unnecessarily expensive (and shouldn't read files it doesn't need to every time)