### PR TITLE
expose the error serialiser for other logger to use

### DIFF
--- a/lib/twiglet/error_serialiser.rb
+++ b/lib/twiglet/error_serialiser.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Twiglet
+  class ErrorSerialiser
+    def serialise_error(error)
+      error_fields = {
+        error: {
+          type: error.class.to_s,
+          message: error.message
+        }
+      }
+      add_stack_trace(error_fields, error)
+    end
+
+    private
+
+    def add_stack_trace(hash_to_add_to, error)
+      hash_to_add_to[:error][:stack_trace] = error.backtrace if error.backtrace
+      hash_to_add_to
+    end
+  end
+end

--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -34,7 +34,7 @@ module Twiglet
         ecs: {
           version: '1.5.0'
         },
-        "@timestamp": @now.call.iso8601(3),
+        '@timestamp': @now.call.iso8601(3),
         service: {
           name: @service_name
         },

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -6,6 +6,7 @@ require_relative 'formatter'
 require_relative '../hash_extensions'
 require_relative 'message'
 require_relative 'validator'
+require_relative 'error_serialiser'
 
 module Twiglet
   class Logger < ::Logger
@@ -87,19 +88,9 @@ module Twiglet
     private
 
     def error_message(error, message = nil)
-      error_fields = {
-        error: {
-          type: error.class.to_s,
-          message: error.message
-        }
-      }
-      add_stack_trace(error_fields, error)
+      error_hash = Twiglet::ErrorSerialiser.new.serialise_error(error)
       message = error.message if message.nil? || message.empty?
-      Message.new(message).merge(error_fields)
-    end
-
-    def add_stack_trace(hash_to_add_to, error)
-      hash_to_add_to[:error][:stack_trace] = error.backtrace if error.backtrace
+      Message.new(message).merge(error_hash)
     end
   end
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.7.2'
+  VERSION = '3.8.0'
 end

--- a/test/error_serialiser_test.rb
+++ b/test/error_serialiser_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'minitest/mock'
+require_relative '../lib/twiglet/error_serialiser'
+
+describe Twiglet::ErrorSerialiser do
+
+  describe 'logging an exception' do
+    it 'should log an error with backtrace' do
+
+      begin
+        1 / 0
+      rescue StandardError => e
+        error_hash = Twiglet::ErrorSerialiser.new.serialise_error(e)
+        assert_equal 'divided by 0', error_hash[:error][:message]
+        assert_equal 'ZeroDivisionError', error_hash[:error][:type]
+        assert_match 'test/error_serialiser_test.rb', error_hash[:error][:stack_trace].first
+      end
+    end
+  end
+end

--- a/test/error_serialiser_test.rb
+++ b/test/error_serialiser_test.rb
@@ -5,18 +5,14 @@ require 'minitest/mock'
 require_relative '../lib/twiglet/error_serialiser'
 
 describe Twiglet::ErrorSerialiser do
-
   describe 'logging an exception' do
     it 'should log an error with backtrace' do
-
-      begin
-        1 / 0
-      rescue StandardError => e
-        error_hash = Twiglet::ErrorSerialiser.new.serialise_error(e)
-        assert_equal 'divided by 0', error_hash[:error][:message]
-        assert_equal 'ZeroDivisionError', error_hash[:error][:type]
-        assert_match 'test/error_serialiser_test.rb', error_hash[:error][:stack_trace].first
-      end
+      1 / 0
+    rescue StandardError => e
+      error_hash = Twiglet::ErrorSerialiser.new.serialise_error(e)
+      assert_equal 'divided by 0', error_hash[:error][:message]
+      assert_equal 'ZeroDivisionError', error_hash[:error][:type]
+      assert_match 'test/error_serialiser_test.rb', error_hash[:error][:stack_trace].first
     end
   end
 end

--- a/test/hash_extensions_test.rb
+++ b/test/hash_extensions_test.rb
@@ -17,7 +17,7 @@ describe HashExtensions do
       log: {
         level: 'error'
       },
-      "@timestamp": '2020-05-09T15:13:20.736Z'
+      '@timestamp': '2020-05-09T15:13:20.736Z'
     }
 
     expected = actual.to_nested
@@ -26,8 +26,8 @@ describe HashExtensions do
 
   it 'should convert keys with . into nested objects' do
     actual = {
-      "service.name": 'petshop',
-      "log.level": 'error'
+      'service.name': 'petshop',
+      'log.level': 'error'
     }
 
     nested = actual.to_nested
@@ -38,10 +38,10 @@ describe HashExtensions do
 
   it 'should group nested objects' do
     actual = {
-      "service.name": 'petshop',
-      "service.id": 'ps001',
-      "service.version": '0.9.1',
-      "log.level": 'error'
+      'service.name': 'petshop',
+      'service.id': 'ps001',
+      'service.version': '0.9.1',
+      'log.level': 'error'
     }
 
     nested = actual.to_nested
@@ -54,10 +54,10 @@ describe HashExtensions do
 
   it 'should cope with more than two levels' do
     actual = {
-      "http.request.method": 'get',
-      "http.request.body.bytes": 112,
-      "http.response.bytes": 1564,
-      "http.response.status_code": 200
+      'http.request.method': 'get',
+      'http.request.body.bytes': 112,
+      'http.response.bytes': 1564,
+      'http.response.status_code': 200
     }
 
     nested = actual.to_nested

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -63,7 +63,7 @@ describe Twiglet::Logger do
         ecs: {
           version: '1.5.0'
         },
-        "@timestamp": '2020-05-11T15:01:01.000Z',
+        '@timestamp': '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
         },
@@ -269,19 +269,19 @@ describe Twiglet::Logger do
       @logger.info({ message: 'there' })
 
       expected_output =
-        '{"ecs":{"version":"1.5.0"},"@timestamp":"2020-05-11T15:01:01.000Z",'\
-        '"service":{"name":"petshop"},"log":{"level":"debug"},"message":"hi"}'\
-        "\n"\
-        '{"ecs":{"version":"1.5.0"},"@timestamp":"2020-05-11T15:01:01.000Z",'\
-        '"service":{"name":"petshop"},"log":{"level":"info"},"message":"there"}'\
-        "\n"\
+        '{"ecs":{"version":"1.5.0"},"@timestamp":"2020-05-11T15:01:01.000Z",' \
+        '"service":{"name":"petshop"},"log":{"level":"debug"},"message":"hi"}' \
+        "\n" \
+        '{"ecs":{"version":"1.5.0"},"@timestamp":"2020-05-11T15:01:01.000Z",' \
+        '"service":{"name":"petshop"},"log":{"level":"info"},"message":"there"}' \
+        "\n" \
 
       assert_equal expected_output, @buffer.string
     end
 
     it 'should work with mixed string and symbol properties' do
       log = {
-        "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
+        'trace.id': '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb'
       }
       event = {}
       log['event'] = event
@@ -404,7 +404,7 @@ describe Twiglet::Logger do
         ecs: {
           version: '1.5.0'
         },
-        "@timestamp": '2020-05-11T15:01:01.000Z',
+        '@timestamp': '2020-05-11T15:01:01.000Z',
         service: {
           name: 'petshop'
         },
@@ -460,11 +460,11 @@ describe Twiglet::Logger do
     it 'should be able to convert dotted keys to nested objects' do
       @logger.debug(
         {
-          "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
+          'trace.id': '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
           message: 'customer bought a dog',
-          "pet.name": 'Barker',
-          "pet.species": 'dog',
-          "pet.breed": 'Bitsa'
+          'pet.name': 'Barker',
+          'pet.species': 'dog',
+          'pet.breed': 'Bitsa'
         }
       )
       log = read_json(@buffer)
@@ -479,10 +479,10 @@ describe Twiglet::Logger do
     it 'should be able to mix dotted keys and nested objects' do
       @logger.debug(
         {
-          "trace.id": '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
+          'trace.id': '1c8a5fb2-fecd-44d8-92a4-449eb2ce4dcb',
           message: 'customer bought a dog',
           pet: { name: 'Barker', breed: 'Bitsa' },
-          "pet.species": 'dog'
+          'pet.species': 'dog'
         }
       )
       log = read_json(@buffer)


### PR DESCRIPTION
# Why

This just make thing abit easier:
the "serialising exception" is a very useful feature for logging, but not all logger has it.

for example in tokenhouse, it doesnt not raise airbrake, but silently log the error and handle 401 more gracefully. however some of the application that uses tokenhouse does not use twiglet. that causes tokenhouse either "lose" this exception logging feature, or the application will raise exception because a standard logger does not handle "error" the way tokenhouse expect logger to.