### PR TITLE
[VIVA-2478] Use JSON.generate instead of to_json

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -47,12 +47,12 @@ module Twiglet
 
       context = @context_provider&.call || {}
 
-      base_message
-        .deep_merge(@default_properties.to_nested)
-        .deep_merge(context.to_nested)
-        .deep_merge(message.to_nested)
-        .to_json
-        .concat("\n")
+      JSON.generate(
+        base_message
+          .deep_merge(@default_properties.to_nested)
+          .deep_merge(context.to_nested)
+          .deep_merge(message.to_nested)
+      ).concat("\n")
     end
   end
 end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.9.0'
+  VERSION = '3.9.1'
 end


### PR DESCRIPTION
This should prevent Sidekiq from failing to start when upgrading to the latest (>7) version.
Offending log coming from Sidekiq where a whole config hash is merged into the message: https://github.com/sidekiq/sidekiq/compare/v6.5.9...v7.1.4#diff-0c49098f0471d2ffa897441bd05c7d24c04ce480e66cb534b194a4bb15e0b201R40

@simplybusiness/vivace   