### PR TITLE
Fix error signature

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,9 +1,11 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: twiglet
+  name: twiglet-ruby
   title: Twiglet
   description: simple logging
+  annotations:   
+    rubygems.org/name: "twiglet"
 spec:
   type: library
   lifecycle: production

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,6 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: twiglet
+  title: Twiglet
   description: simple logging
 spec:
   type: library

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -62,8 +62,14 @@ module Twiglet
       super(message, &block)
     end
 
-    def error(message = nil, error = nil, &block)
-      message = error_message(error, message) if error
+    def error(message_or_error = nil, error = nil, &block)
+      if error 
+        message = error_message(error, message_or_error)
+      elsif message_or_error.is_a?(Exception)
+        message = error_message(message_or_error)
+      else
+        message = message_or_error
+      end
 
       super(message, &block)
     end

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -63,13 +63,13 @@ module Twiglet
     end
 
     def error(message_or_error = nil, error = nil, &block)
-      if error 
-        message = error_message(error, message_or_error)
-      elsif message_or_error.is_a?(Exception)
-        message = error_message(message_or_error)
-      else
-        message = message_or_error
-      end
+      message = if error
+                  error_message(error, message_or_error)
+                elsif message_or_error.is_a?(Exception)
+                  error_message(message_or_error)
+                else
+                  message_or_error
+                end
 
       super(message, &block)
     end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.9.1'
+  VERSION = '3.9.2'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -335,8 +335,8 @@ describe Twiglet::Logger do
       actual_log = read_json(@buffer)
 
       assert_equal 'Artificially raised exception', actual_log[:message]
-      assert_equal 'divided by 0', actual_log[:error][:message]
       assert_equal 'ZeroDivisionError', actual_log[:error][:type]
+      assert_equal 'divided by 0', actual_log[:error][:message]
       assert_match 'test/logger_test.rb', actual_log[:error][:stack_trace].first
     end
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -373,7 +373,7 @@ describe Twiglet::Logger do
       assert_equal 'StandardError', actual_log[:error][:type]
       assert_equal 'Some error', actual_log[:error][:message]
     end
-    
+
     it 'should log an error if nil message is given' do
       e = StandardError.new('Some error')
       @logger.error(nil, e)

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -353,14 +353,44 @@ describe Twiglet::Logger do
     end
 
     it 'should log an error with string message' do
-      e = StandardError.new('Unknown error')
+      e = StandardError.new('Some error')
       @logger.error('Artificially raised exception with string message', e)
 
       actual_log = read_json(@buffer)
 
       assert_equal 'Artificially raised exception with string message', actual_log[:message]
       assert_equal 'StandardError', actual_log[:error][:type]
-      assert_equal 'Unknown error', actual_log[:error][:message]
+      assert_equal 'Some error', actual_log[:error][:message]
+    end
+
+    it 'should log an error if no message is given' do
+      e = StandardError.new('Some error')
+      @logger.error(e)
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'Some error', actual_log[:message]
+      assert_equal 'StandardError', actual_log[:error][:type]
+      assert_equal 'Some error', actual_log[:error][:message]
+    end
+    
+    it 'should log an error if nil message is given' do
+      e = StandardError.new('Some error')
+      @logger.error(nil, e)
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'Some error', actual_log[:message]
+      assert_equal 'StandardError', actual_log[:error][:type]
+      assert_equal 'Some error', actual_log[:error][:message]
+    end
+
+    it 'should log a string if no error is given' do
+      @logger.error('Some error')
+
+      actual_log = read_json(@buffer)
+
+      assert_equal 'Some error', actual_log[:message]
     end
 
     it 'should log error type properly even when active_support/json is required' do
@@ -371,17 +401,6 @@ describe Twiglet::Logger do
       actual_log = read_json(@buffer)
 
       assert_equal 'StandardError', actual_log[:error][:type]
-    end
-
-    it 'can log just an error as "error", if no message is given' do
-      e = StandardError.new('some error')
-      @logger.error(nil, e)
-
-      actual_log = read_json(@buffer)
-
-      assert_equal 'some error', actual_log[:message]
-      assert_equal 'StandardError', actual_log[:error][:type]
-      assert_equal 'some error', actual_log[:error][:message]
     end
 
     [:debug, :info, :warn].each do |level|


### PR DESCRIPTION
This changes the `Twiglet` `.error` signature to be able to handle a single error argument like the base `Logger` does. 

The only way that `Twiglet` `.error` now differs from the standard is that it will allow separate message and error args. The standard `Logger` will raise an error if passed more than one argument, but `Twiglet` won't to preserve backwards compatibility for anyone who is using it that way. 