### PR TITLE
add title to catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,6 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: twiglet
+  title: Twiglet
   description: simple logging
 spec:
   type: library


### PR DESCRIPTION
Because some repos have title case titles in Backstage and some don't so trying to make it look neater by standardising it as name - lowercase, title - titlecase.