### PR TITLE
preserve context when adding a new context provider

### DIFF
--- a/lib/hash_extensions.rb
+++ b/lib/hash_extensions.rb
@@ -2,7 +2,7 @@
 
 module HashExtensions
   def to_nested
-    self unless contains_dotted_key?
+    return self unless contains_dotted_key?
 
     keys.reduce({}) do |nested, key|
       nested.deep_merge(build_nested_object(key, self[key]))

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -82,9 +82,15 @@ module Twiglet
     end
 
     def context_provider(&blk)
+      new_context_provider = blk
+      if @args[:context_provider]
+        new_context_provider = lambda do
+          @args[:context_provider].call.merge(blk.call)
+        end
+      end
       self.class.new(
         @service_name,
-        **@args.merge(context_provider: blk)
+        **@args.merge(context_provider: new_context_provider)
       )
     end
 

--- a/lib/twiglet/message.rb
+++ b/lib/twiglet/message.rb
@@ -8,7 +8,7 @@ module Twiglet
       when Hash
         replace(msg.transform_keys!(&:to_sym))
       else
-        super(msg)
+        super
       end
     end
   end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.9.2'
+  VERSION = '3.10.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -266,6 +266,27 @@ describe Twiglet::Logger do
       assert_equal 'my-context-id', log[:context][:id]
     end
 
+    it "previously supplied context providers should be preserved" do
+      # Let's add some context to this customer journey
+      purchase_logger = @logger
+                        .context_provider { { 'first-context' => { 'first-id' => 'my-first-context-id' } } }
+                        .context_provider { { 'second-context' => { 'second-id' => 'my-second-context-id' } } }
+      # do stuff
+      purchase_logger.info(
+        {
+          message: 'customer bought a dog',
+          pet: { name: 'Barker', species: 'dog', breed: 'Bitsa' }
+        }
+      )
+
+      log = read_json @buffer
+
+      assert_equal 'customer bought a dog', log[:message]
+      assert_equal 'Barker', log[:pet][:name]
+      assert_equal 'my-first-context-id', log[:'first-context'][:'first-id']
+      assert_equal 'my-second-context-id', log[:'second-context'][:'second-id']
+    end
+
     it "should log 'message' string property" do
       message = {}
       message['message'] = 'Guinea pigs arrived'

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'minitest/mock'
 require_relative '../lib/twiglet/logger'
+require 'active_support'
 
 LEVELS = [
   { method: :debug, level: 'debug' },
@@ -414,8 +415,7 @@ describe Twiglet::Logger do
       assert_equal 'Some error', actual_log[:message]
     end
 
-    it 'should log error type properly even when active_support/json is required' do
-      require 'active_support/json'
+    it 'should log error type properly even when active_support is required' do
       e = StandardError.new('Unknown error')
       @logger.error('Artificially raised exception with string message', e)
 

--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.license               = 'Copyright SimplyBusiness'
 
-  gem.add_runtime_dependency     'json-schema'
+  gem.add_dependency 'json-schema'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov', '0.17.1'


### PR DESCRIPTION
This is common need when creating a domain specific logger: we may want to provide domain specific ids (like user/session ids) inline with some generic ones (like Otel ids). Currently, we have to create a single lambda with all of the behaviour in it, which leads to lots of duplicated across apps.