### PR TITLE
Context providers refactor

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -11,12 +11,13 @@ module Twiglet
       validator:,
       default_properties: {},
       context_provider: nil,
+      context_providers: [],
       now: -> { Time.now.utc }
     )
       @service_name = service_name
       @now = now
       @default_properties = default_properties
-      @context_provider = context_provider
+      @context_providers = context_provider ? [context_provider] : context_providers
       @validator = validator
 
       super()
@@ -45,7 +46,9 @@ module Twiglet
         }
       }
 
-      context = @context_provider&.call || {}
+      context = @context_providers.reduce({}) do |c, context_provider|
+        c.deep_merge(context_provider.call)
+      end
 
       JSON.generate(
         base_message

--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -33,7 +33,7 @@ module Twiglet
       formatter = Twiglet::Formatter.new(
         service_name,
         default_properties: args.fetch(:default_properties, {}),
-        context_provider: args[:context_provider],
+        context_providers: Array(args[:context_provider] || args[:context_providers]),
         now: now,
         validator: @validator
       )
@@ -82,15 +82,12 @@ module Twiglet
     end
 
     def context_provider(&blk)
-      new_context_provider = blk
-      if @args[:context_provider]
-        new_context_provider = lambda do
-          @args[:context_provider].call.merge(blk.call)
-        end
-      end
+      new_context_providers = Array(@args[:context_providers])
+      new_context_providers << blk
+
       self.class.new(
         @service_name,
-        **@args.merge(context_provider: new_context_provider)
+        **@args.merge(context_providers: new_context_providers)
       )
     end
 

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.10.0'
+  VERSION = '3.11.0'
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -58,4 +58,32 @@ describe Twiglet::Formatter do
     }
     assert_equal JSON.parse(msg), expected_log
   end
+
+  it 'merges the outputs of all context providers into the messages log' do
+    provider_1 = -> { { 'request' => { 'id' => '1234567890' } } }
+    provider_2 = -> { { 'request' => { 'type' => 'test' } } }
+    formatter = Twiglet::Formatter.new(
+      'petshop', now: @now, validator: Twiglet::Validator.new({}.to_json),
+                 context_providers: [provider_1, provider_2]
+    )
+    msg = formatter.call('warn', nil, nil, 'shop is running low on dog food')
+    expected_log = {
+      "ecs" => {
+        "version" => '1.5.0'
+      },
+      "@timestamp" => '2020-05-11T15:01:01.000Z',
+      "service" => {
+        "name" => 'petshop'
+      },
+      "log" => {
+        "level" => 'warn'
+      },
+      "message" => 'shop is running low on dog food',
+      "request" => {
+        'id' => '1234567890',
+        'type' => 'test'
+      }
+    }
+    assert_equal expected_log, JSON.parse(msg)
+  end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -189,9 +189,13 @@ describe Twiglet::Logger do
     end
 
     it "should be able to add contextual information to events with the context_provider" do
-      purchase_logger = @logger.context_provider do
-        { 'context' => { 'id' => 'my-context-id' } }
-      end
+      provider = -> { { 'context' => { 'id' => 'my-context-id' } } }
+      purchase_logger = Twiglet::Logger.new(
+        'petshop',
+        now: @now,
+        output: @buffer,
+        context_provider: provider
+      )
 
       # do stuff
       purchase_logger.info(

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -211,6 +211,31 @@ describe Twiglet::Logger do
       assert_equal 'my-context-id', log[:context][:id]
     end
 
+    it "should be able to add contextual information to events with multiple context providers" do
+      provider_1 = -> { { 'context' => { 'id' => 'my-context-id' } } }
+      provider_2 = -> { { 'context' => { 'type' => 'test' } } }
+      purchase_logger = Twiglet::Logger.new(
+        'petshop',
+        now: @now,
+        output: @buffer,
+        context_providers: [provider_1, provider_2]
+      )
+
+      # do stuff
+      purchase_logger.info(
+        {
+          message: 'customer bought a dog',
+          pet: { name: 'Barker', species: 'dog', breed: 'Bitsa' }
+        }
+      )
+
+      log = read_json @buffer
+
+      assert_equal 'customer bought a dog', log[:message]
+      assert_equal 'my-context-id', log[:context][:id]
+      assert_equal 'test', log[:context][:type]
+    end
+
     it "chaining .with and .context_provider is possible" do
       # Let's add some context to this customer journey
       purchase_logger = @logger.with(


### PR DESCRIPTION
This refactors context providers to an array of lambdas, rather than wrapping lambdas within other lambdas. This is mostly for simplicity in general - in terms of understanding, reading, debugging. It should be easier to understand the state your logger is in, because the syntax location of any context providers should point to their actual location in code, rather than the wrapping lambda that's within `lib/twiglet/logger.rb`. This should be backwards compatible with existing code (that's the intention). This also adds a little bit of extra test coverage (i.e. passing a context provider to the `Logger` initializer).