### PR TITLE
VIVA-2846 - Change default log level to info

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -22,7 +22,7 @@ module Twiglet
 
       now = args.fetch(:now, -> { Time.now.utc })
       output = args.fetch(:output, $stdout)
-      level = args.fetch(:level, DEBUG)
+      level = args.fetch(:level, INFO)
       validation_schema = args.fetch(:validation_schema, DEFAULT_VALIDATION_SCHEMA)
 
       raise 'Service name is mandatory' \

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.11.0'
+  VERSION = '3.12.0'
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -23,7 +23,8 @@ describe Twiglet::Logger do
     @logger = Twiglet::Logger.new(
       'petshop',
       now: @now,
-      output: @buffer
+      output: @buffer,
+      level: Logger::DEBUG
     )
   end
 
@@ -652,7 +653,8 @@ describe Twiglet::Logger do
         'petshop',
         now: @now,
         output: @buffer,
-        validation_schema: validation_schema
+        validation_schema: validation_schema,
+        level: Logger::DEBUG
       )
     end
 


### PR DESCRIPTION
We want to change the log level to info so that we don’t log debug messages in live production environments (both to reduce noise and reduce amount of processing our logging infrastructure needs to do).