### PR TITLE
support overriding validation schemas

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -81,6 +81,13 @@ module Twiglet
       )
     end
 
+    def validation_schema(validation_schema)
+      self.class.new(
+        @service_name,
+        **@args.merge(validation_schema: validation_schema)
+      )
+    end
+
     def context_provider(&blk)
       new_context_providers = Array(@args[:context_providers])
       new_context_providers << blk

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.12.0'
+  VERSION = '3.13.0'
 end


### PR DESCRIPTION
This creates a new Twiglet logger that uses a custom validation schema. This is helpful when you want to preserve configuration across loggers but use different schemas. This is required for getting sidekiq logs working with Twiglet.