### PR TITLE
Update Ubuntu version in GitHub Actions workflows

### DIFF
--- a/.github/workflows/dobby-actions.yml
+++ b/.github/workflows/dobby-actions.yml
@@ -1,4 +1,3 @@
-
 name: "Dobby action"
 on:
   issue_comment:
@@ -7,7 +6,7 @@ permissions:
   contents: read
 jobs:
   pr_commented:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: startsWith(github.event.comment.body, '/dobby')
     env:
       BUNDLE_WITHOUT: "development:test"

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.14.0'
+  VERSION = '3.14.1'
 end


### PR DESCRIPTION
Update the `runs-on` value in the `.github/workflows/dobby-actions.yml` file to use `ubuntu-latest` instead of `ubuntu-20.04`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/simplybusiness/twiglet-ruby/pull/101?shareId=eb2d1b2d-eec5-4c64-ae16-2b503772aed7).