### PR TITLE
reuse schema validator object

### DIFF
--- a/lib/twiglet/logger.rb
+++ b/lib/twiglet/logger.rb
@@ -23,12 +23,12 @@ module Twiglet
       now = args.fetch(:now, -> { Time.now.utc })
       output = args.fetch(:output, $stdout)
       level = args.fetch(:level, INFO)
-      validation_schema = args.fetch(:validation_schema, DEFAULT_VALIDATION_SCHEMA)
+      schema = args.fetch(:validation_schema, DEFAULT_VALIDATION_SCHEMA)
 
       raise 'Service name is mandatory' \
         unless service_name.is_a?(String) && !service_name.strip.empty?
 
-      @validator = Validator.new(validation_schema)
+      @validator = Validator.new(schema)
 
       formatter = Twiglet::Formatter.new(
         service_name,

--- a/lib/twiglet/validator.rb
+++ b/lib/twiglet/validator.rb
@@ -10,10 +10,11 @@ module Twiglet
     def initialize(schema)
       @schema = JSON.parse(schema)
       @custom_error_handler = ->(e) { raise e }
+      @validator = JSON::Validator.new(@schema)
     end
 
     def validate(message)
-      JSON::Validator.validate!(@schema, message)
+      @validator.validate(message)
     rescue JSON::Schema::ValidationError => e
       custom_error_handler.call(e)
     end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.14.1'
+  VERSION = '3.14.2'
 end


### PR DESCRIPTION
When we log we have been validating schemas using a fresh validator object each time, through JSON::Validator.validate!. This create wastes as we're creating a new validator and parsing the schema for each log message.

Reusing the validator avoids this waste.