### PR TITLE
Enhance gem publishing workflow with OIDC support and add trusted pub…

### DIFF
--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.3, 3.4]
+        ruby-version: [3.1, 3.2, 3.3, 3.4]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Ruby

--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.1, 3.2, 3.3, 3.4]
+        ruby-version: [3.2, 3.3, 3.4]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Ruby

--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -6,27 +6,42 @@ on:
 
 permissions:
   contents: write
+  id-token: write # Required for OIDC token
 
 jobs:
-  build:
-    name: Build and Publish
+  test:
+    name: Run Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: [3.1, 3.2, 3.3, 3.4]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test
+
+  build:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Configure RubyGems for OIDC
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
+      - name: Build gem
+        run: gem build *.gemspec
       - name: Publish to RubyGems
-        run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem build *.gemspec
-          gem push *.gem
-        env:
-          GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+        run: gem push *.gem
       - name: Get Gem Version
         id: get-gem-version
         run: echo "GEM_VERSION=$(bundle exec ruby -e 'puts Twiglet::VERSION')" >> $GITHUB_OUTPUT

--- a/docs/TRUSTED_PUBLISHING.md
+++ b/docs/TRUSTED_PUBLISHING.md
@@ -1,0 +1,42 @@
+# Trusted Publishing Setup
+
+This repository now uses RubyGems trusted publishing via GitHub Actions OIDC tokens, eliminating the need for stored API keys.
+
+## How it works
+
+1. **Automated Publishing**: When code is pushed to the `master` branch, the workflow automatically:
+   - Runs the full test suite across multiple Ruby versions (3.1, 3.2, 3.3, 3.4)
+   - Builds the gem if tests pass
+   - Publishes to RubyGems using OIDC token authentication
+   - Creates a GitHub release
+
+2. **Security**: No stored credentials are needed. Authentication happens via:
+   - GitHub's OIDC token provider
+   - RubyGems trusted publishing configuration
+   - Repository-specific permissions
+
+## Configuration Required
+
+To enable trusted publishing for this gem on RubyGems:
+
+1. Go to <https://rubygems.org/gems/twiglet/trusted_publishers>
+2. Add a new trusted publisher with:
+   - **Repository**: `simplybusiness/twiglet-ruby`
+   - **Workflow**: `gem-publish.yml`
+   - **Environment**: (leave blank)
+
+## Benefits
+
+- ✅ No stored API keys or secrets
+- ✅ Automatic key rotation via OIDC tokens
+- ✅ Repository-scoped permissions
+- ✅ Audit trail through GitHub Actions
+- ✅ Tests must pass before publishing
+
+## Workflow Details
+
+The publishing workflow (`/.github/workflows/gem-publish.yml`) uses:
+
+- `rubygems/configure-rubygems-credentials@v1.0.0` for OIDC authentication
+- Required permissions: `id-token: write` and `contents: write`
+- Multi-stage process: test → build → publish → release

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.14.4'
+  VERSION = '3.14.5'
 end

--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -14,6 +14,14 @@ Gem::Specification.new do |gem|
   gem.summary               = 'Twiglet'
   gem.description           = 'Like a log, only smaller.'
 
+  # Required metadata for trusted publishing
+  gem.metadata = {
+    'source_code_uri'   => 'https://github.com/simplybusiness/twiglet-ruby',
+    'changelog_uri'     => 'https://github.com/simplybusiness/twiglet-ruby/releases',
+    'bug_tracker_uri'   => 'https://github.com/simplybusiness/twiglet-ruby/issues',
+    'documentation_uri' => 'https://github.com/simplybusiness/twiglet-ruby'
+  }
+
   gem.files                 = `git ls-files`.split("\n")
 
   gem.require_paths         = ['lib']

--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
 
   # Required metadata for trusted publishing
   gem.metadata = {
-    'source_code_uri'   => 'https://github.com/simplybusiness/twiglet-ruby',
-    'changelog_uri'     => 'https://github.com/simplybusiness/twiglet-ruby/releases',
-    'bug_tracker_uri'   => 'https://github.com/simplybusiness/twiglet-ruby/issues',
+    'source_code_uri' => 'https://github.com/simplybusiness/twiglet-ruby',
+    'changelog_uri' => 'https://github.com/simplybusiness/twiglet-ruby/releases',
+    'bug_tracker_uri' => 'https://github.com/simplybusiness/twiglet-ruby/issues',
     'documentation_uri' => 'https://github.com/simplybusiness/twiglet-ruby'
   }
 


### PR DESCRIPTION
…lishing documentation

This pull request introduces trusted publishing for the gem, improving both security and automation of the release process. The workflow now uses GitHub Actions OIDC tokens for authentication with RubyGems, removing the need for stored API keys and ensuring that all tests pass before publishing. Documentation and gem metadata have also been updated to support and explain the new process.

**Trusted publishing and workflow automation:**

* Updated `.github/workflows/gem-publish.yml` to use RubyGems trusted publishing via OIDC tokens, run tests across multiple Ruby versions, and require tests to pass before publishing. The workflow now uses `rubygems/configure-rubygems-credentials@v1.0.0` for authentication and removes the need for API keys.

**Documentation improvements:**

* Added `docs/TRUSTED_PUBLISHING.md` to document the trusted publishing setup, configuration steps, security benefits, and workflow details.

**Gem metadata updates:**

* Added required metadata fields (`source_code_uri`, `changelog_uri`, `bug_tracker_uri`, `documentation_uri`) to `twiglet.gemspec` to support trusted publishing and improve discoverability.