### PR TITLE
Update gem-publish workflow to use dynamic Ruby version and streamlin…

### DIFF
--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -34,14 +34,9 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: ruby
           bundler-cache: true
-      - name: Configure RubyGems for OIDC
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
-      - name: Build gem
-        run: gem build *.gemspec
-      - name: Publish to RubyGems
-        run: gem push *.gem
+      - uses: rubygems/release-gem@v1
       - name: Get Gem Version
         id: get-gem-version
         run: echo "GEM_VERSION=$(bundle exec ruby -e 'puts Twiglet::VERSION')" >> $GITHUB_OUTPUT

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require 'rake/testtask'
+require 'bundler/gem_tasks'
 
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList['test/test_coverage.rb', 'test/*_test.rb', 'examples/rack/request_logger_test.rb']
   t.verbose = true
 end
+
+task default: :test


### PR DESCRIPTION
…e gem release process

This pull request updates the gem publishing workflow and improves the build and test setup. The most important changes include simplifying the GitHub Actions workflow for gem publishing and enhancing the Rakefile for easier test execution and gem management.

**CI/CD and Gem Publishing Workflow Improvements:**

* The `.github/workflows/gem-publish.yml` workflow now uses the `rubygems/release-gem@v1` action for building and publishing gems, replacing manual steps and OIDC configuration for RubyGems credentials. This streamlines the release process and reduces maintenance overhead.
* The Ruby setup step in the workflow now uses the default Ruby version specified in the environment, improving compatibility and reducing hardcoding.

**Build and Test Setup Enhancements:**

* The `Rakefile` now requires `bundler/gem_tasks`, enabling standard gem-related rake tasks such as build, install, and release.
* The default rake task is set to run tests, making it easier to execute the test suite with a simple `rake` command.