### PR TITLE
Trusted publishing

### DIFF
--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -34,14 +34,9 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: ruby
           bundler-cache: true
-      - name: Configure RubyGems for OIDC
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
-      - name: Build gem
-        run: gem build *.gemspec
-      - name: Publish to RubyGems
-        run: gem push *.gem
+      - uses: rubygems/release-gem@v1
       - name: Get Gem Version
         id: get-gem-version
         run: echo "GEM_VERSION=$(bundle exec ruby -e 'puts Twiglet::VERSION')" >> $GITHUB_OUTPUT

--- a/.github/workflows/gem-publish.yml
+++ b/.github/workflows/gem-publish.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [ master ]
 
-permissions:
-  contents: write
-  id-token: write # Required for OIDC token
-
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+
     strategy:
       matrix:
         ruby-version: [3.1, 3.2, 3.3, 3.4]
@@ -28,13 +28,18 @@ jobs:
   build:
     name: Build and Publish
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write # Required for OIDC token
+
     needs: test
     steps:
       - uses: actions/checkout@v5
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ruby
+          ruby-version: .ruby-version
           bundler-cache: true
       - uses: rubygems/release-gem@v1
       - name: Get Gem Version

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require 'rake/testtask'
+require 'bundler/gem_tasks'
 
 Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList['test/test_coverage.rb', 'test/*_test.rb', 'examples/rack/request_logger_test.rb']
   t.verbose = true
 end
+
+task default: :test

--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.name                  = 'twiglet'
   gem.version               = Twiglet::VERSION
   gem.authors               = ['Simply Business']
-  gem.email                 = ['tech@simplybusiness.co.uk']
+  gem.email                 = ['opensourcetech+rubygems@simplybusiness.co.uk']
   gem.homepage              = 'https://github.com/simplybusiness/twiglet-ruby'
 
   gem.summary               = 'Twiglet'
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.require_paths         = ['lib']
   gem.required_ruby_version = ['>= 3.1 ', '< 3.5']
 
-  gem.license               = 'Copyright SimplyBusiness'
+  gem.license               = 'MIT'
 
   gem.add_dependency 'json-schema'
   gem.add_development_dependency 'minitest'


### PR DESCRIPTION
This pull request updates the gem publishing workflow and project configuration to streamline the release process, improve permissions management, and update project metadata. The main changes are in the GitHub Actions workflow, the gemspec, and the Rakefile.

**Workflow and Release Process Improvements**

* Moved job-specific permissions into each job in `.github/workflows/gem-publish.yml`, granting `contents: read` to the `test` job and `contents: write`/`id-token: write` to the `build` job for better security and clarity. [[1]](diffhunk://#diff-dfc8c47d891487b35bfcf0d7a7efa874f0fe53021544ec98a0d91d945f299e80L7-R14) [[2]](diffhunk://#diff-dfc8c47d891487b35bfcf0d7a7efa874f0fe53021544ec98a0d91d945f299e80R31-R44)
* Replaced manual RubyGems publishing steps with the standardized `rubygems/release-gem@v1` action, simplifying and standardizing the gem release process.
* Updated Ruby version setup in the workflow to use the `.ruby-version` file, ensuring consistency with local development environments.

**Project Configuration Updates**

* Added `require 'bundler/gem_tasks'` and set the default rake task to `:test` in `Rakefile`, improving developer experience and build consistency.
* Changed the gem license from a custom copyright to `MIT` and updated the contact email to a more appropriate address in `twiglet.gemspec`, ensuring proper open source compliance and communication. [[1]](diffhunk://#diff-3cb4af085783462d495dfe480123fa1739cbc439cbebe4469a6667a1f7d960e2L11-R11) [[2]](diffhunk://#diff-3cb4af085783462d495dfe480123fa1739cbc439cbebe4469a6667a1f7d960e2L30-R30)