### PR TITLE
Refactor gemspec to explicitly define gem files instead of using git …

### DIFF
--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     'documentation_uri' => 'https://github.com/simplybusiness/twiglet-ruby'
   }
 
-  gem.files                 = Dir['lib/**/*', 'LICENSE', 'README.md']
+  gem.files                 = Dir.glob(['lib/**/*', 'LICENSE', 'README.md']).reject { |f| File.directory?(f) }
 
   gem.require_paths         = ['lib']
   gem.required_ruby_version = ['>= 3.1 ', '< 3.5']

--- a/twiglet.gemspec
+++ b/twiglet.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     'documentation_uri' => 'https://github.com/simplybusiness/twiglet-ruby'
   }
 
-  gem.files                 = `git ls-files`.split("\n")
+  gem.files                 = Dir['lib/**/*', 'LICENSE', 'README.md']
 
   gem.require_paths         = ['lib']
   gem.required_ruby_version = ['>= 3.1 ', '< 3.5']


### PR DESCRIPTION
…ls-files

This pull request updates the way gem files are specified in the `twiglet.gemspec` file. Instead of using `git ls-files` to list files, it now explicitly includes only the contents of the `lib` directory, the `LICENSE`, and the `README.md`. This change makes the gem packaging process more predictable and avoids including unintended files.

Gem packaging configuration:

* Changed the `gem.files` assignment to use `Dir['lib/**/*', 'LICENSE', 'README.md']` instead of relying on `git ls-files`, ensuring only essential files are packaged with the gem.