### PR TITLE
Fix: Prevent a missing message caused raise from hiding another raise

### DIFF
--- a/lib/twiglet/formatter.rb
+++ b/lib/twiglet/formatter.rb
@@ -28,6 +28,9 @@ module Twiglet
       message = Message.new(msg)
       @validator.validate(message)
       log(level: level, message: message)
+    rescue StandardError => e
+      Kernel.warn("Twiglet formatting error: #{e.message}")
+      fallback_log(level: level || 'error', message: msg, error: e)
     end
 
     private
@@ -55,6 +58,19 @@ module Twiglet
           .deep_merge(@default_properties.to_nested)
           .deep_merge(context.to_nested)
           .deep_merge(message.to_nested)
+      ).concat("\n")
+    end
+
+    def fallback_log(level:, message:, error:)
+      JSON.generate(
+        {
+          ecs: { version: '1.5.0' },
+          '@timestamp': @now.call.iso8601(3),
+          service: { name: @service_name },
+          log: { level: level },
+          message: message.to_s,
+          twiglet_error: "#{error.class}: #{error.message}"
+        }
       ).concat("\n")
     end
   end

--- a/lib/twiglet/version.rb
+++ b/lib/twiglet/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Twiglet
-  VERSION = '3.16.0'
+  VERSION = '3.17.0'
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -86,4 +86,24 @@ describe Twiglet::Formatter do
     }
     assert_equal expected_log, JSON.parse(msg)
   end
+
+  it 'produces a fallback log when formatting fails' do
+    validator = Twiglet::Validator.new(Twiglet::Logger::DEFAULT_VALIDATION_SCHEMA)
+    formatter = Twiglet::Formatter.new('petshop', now: @now, validator: validator)
+
+    msg = formatter.call('warn', nil, nil, '')
+    parsed = JSON.parse(msg)
+
+    assert_equal 'warn', parsed.dig('log', 'level')
+    assert_equal 'petshop', parsed.dig('service', 'name')
+    assert_includes parsed['twiglet_error'], 'ValidationError'
+  end
+
+  it 'does not raise when formatting fails' do
+    validator = Twiglet::Validator.new(Twiglet::Logger::DEFAULT_VALIDATION_SCHEMA)
+    formatter = Twiglet::Formatter.new('petshop', now: @now, validator: validator)
+
+    result = formatter.call('error', nil, nil, { message: true })
+    assert_kind_of String, result
+  end
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -55,16 +55,16 @@ describe Twiglet::Logger do
   end
 
   describe 'JSON logging' do
-    it 'should throw an error with an empty message' do
-      assert_raises JSON::Schema::ValidationError, "The property '#/message' was not of a minimum string length of 1" do
-        @logger.info({ message: '' })
-      end
+    it 'should produce a fallback log with an empty message' do
+      @logger.info({ message: '' })
+      actual_log = read_json(@buffer)
+      assert_includes actual_log[:twiglet_error], 'ValidationError'
     end
 
-    it 'should throw an error if message is missing' do
-      assert_raises JSON::Schema::ValidationError, "The property '#/message' was not of a minimum string length of 1" do
-        @logger.info({ foo: 'bar' })
-      end
+    it 'should produce a fallback log if message is missing' do
+      @logger.info({ foo: 'bar' })
+      actual_log = read_json(@buffer)
+      assert_includes actual_log[:twiglet_error], 'ValidationError'
     end
 
     it 'should log mandatory attributes' do
@@ -470,10 +470,10 @@ describe Twiglet::Logger do
   end
 
   describe 'text logging' do
-    it 'should throw an error with an empty message' do
-      assert_raises JSON::Schema::ValidationError, "The property '#/message' was not of a minimum string length of 1" do
-        @logger.info('')
-      end
+    it 'should produce a fallback log with an empty message' do
+      @logger.info('')
+      actual_log = read_json(@buffer)
+      assert_includes actual_log[:twiglet_error], 'ValidationError'
     end
 
     it 'should log mandatory attributes' do
@@ -605,11 +605,10 @@ describe Twiglet::Logger do
   end
 
   describe 'configuring error response' do
-    it 'blows up by default' do
-      assert_raises JSON::Schema::ValidationError,
-                    "The property '#/message' of type boolean did not match the following type: string" do
-        @logger.debug(message: true)
-      end
+    it 'produces a fallback log by default' do
+      @logger.debug(message: true)
+      actual_log = read_json(@buffer)
+      assert_includes actual_log[:twiglet_error], 'ValidationError'
     end
 
     it 'silently swallows errors when configured to do so' do
@@ -669,15 +668,14 @@ describe Twiglet::Logger do
       assert_equal true, log[:pet][:best_boy_or_girl?]
     end
 
-    it 'raises when custom validation rules are broken' do
+    it 'produces a fallback log when custom validation rules are broken' do
       nonconformant = {
         pet: { name: 'Davis' }
       }
 
-      assert_raises JSON::Schema::ValidationError,
-                    "The property '#/pet' did not contain a required property of 'best_boy_or_girl?'" do
-        @logger.debug(nonconformant)
-      end
+      @logger.debug(nonconformant)
+      actual_log = read_json(@buffer)
+      assert_includes actual_log[:twiglet_error], 'ValidationError'
     end
   end
 
@@ -721,18 +719,19 @@ describe Twiglet::Logger do
       log = read_json(@buffer)
       assert_equal 'hi', log[:message]
 
-      error = assert_raises JSON::Schema::ValidationError do
-        logger.info(pet_message)
-      end
-      assert_equal "The property '#/' did not contain a required property of 'message'", error.message
+      @buffer.truncate(0)
+      logger.info(pet_message)
+      log = read_json(@buffer)
+      assert_includes log[:twiglet_error], "did not contain a required property of 'message'"
 
       logger = logger.validation_schema(validation_schema)
 
-      error = assert_raises JSON::Schema::ValidationError do
-        logger.info(message)
-      end
-      assert_equal "The property '#/' did not contain a required property of 'pet'", error.message
+      @buffer.truncate(0)
+      logger.info(message)
+      log = read_json(@buffer)
+      assert_includes log[:twiglet_error], "did not contain a required property of 'pet'"
 
+      @buffer.truncate(0)
       logger.info(pet_message)
       log = read_json(@buffer)
       assert_equal 'Davis', log[:pet][:name]


### PR DESCRIPTION
### Problem
If the `raise` doesn't send a message, when it tries to log the error then twiglet itself raises a validation error.
This second raise actually hides the first raise.

### Solution
If twiglet would raise for any reason, fall back to a simple json format that is pre-defined.
